### PR TITLE
Fix `unsafe_read` on views of `Vector{UInt8}` with non `Int` ranges

### DIFF
--- a/src/InputBuffers.jl
+++ b/src/InputBuffers.jl
@@ -116,7 +116,7 @@ const ByteVector = Union{
 function Base.unsafe_read(b::InputBuffer{<:ByteVector}, p::Ptr{UInt8}, n::UInt)::Nothing
     nb::Int64 = min(n, bytesavailable(b)) # errors if closed
     data = b.data
-    GC.@preserve data unsafe_copyto!(p, pointer(data, firstindex(data) + b.pos), nb)
+    GC.@preserve data unsafe_copyto!(p, pointer(data, Int(firstindex(data) + b.pos)), nb)
     b.pos += nb
     nb < n && throw(EOFError())
     nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -267,6 +267,15 @@ using CRC32: crc32
             @test position(b) == len
         end
         @test_throws Exception InputBuffer(Zeros{UInt8}(typemax(UInt64)))
+
+        # FastContiguousSubArray with non Int indexes
+        for T in (BigInt, UInt64, Int64)
+            b = InputBuffer(view(zeros(UInt8,1000), T(2):T(90)))
+            @test read(b, UInt8) === UInt8(0)
+            data = ones(UInt8, 5)
+            GC.@preserve data unsafe_read(b, pointer(data), 5) === nothing
+            @test data == zeros(UInt8, 5)
+        end
     end
     @testset "closing" begin
         b = InputBuffer(b"foo")


### PR DESCRIPTION
`pointer` on a `view` seems to require the index argument to be an `Int`