### PR TITLE
BREAKING: Make close a no-op

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InputBuffers"
 uuid = "0c81fc1b-5583-44fc-8770-48be1e1cca08"
 authors = ["nhz2 <nhz2@cornell.edu> and contributors"]
-version = "0.1.1"
+version = "0.2.0"
 
 [compat]
 julia = "1.6"

--- a/src/InputBuffers.jl
+++ b/src/InputBuffers.jl
@@ -20,6 +20,7 @@ end
 
 Base.close(::InputBuffer)::Nothing = nothing
 Base.isopen(::InputBuffer)::Bool = true
+Base.isreadable(::InputBuffer)::Bool = true
 Base.iswritable(::InputBuffer)::Bool = false
 
 function Base.eof(b::InputBuffer)::Bool

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -190,8 +190,8 @@ using CRC32: crc32
         @test !ismarked(stream)
         @test !unmark(stream)
         @test mark(stream) == 3
-        close(stream)
-        @test !ismarked(stream)
+        close(stream) # This is a no-op
+        @test ismarked(stream)
     
         stream = InputBuffer(b"foobarbaz")
         @test stream == seek(stream, 2)
@@ -214,11 +214,6 @@ using CRC32: crc32
         skip(stream, 7)
         @test eof(stream)
         close(stream)
-
-        stream = InputBuffer(b"")
-        @test eof(stream)
-        close(stream)
-        @test_throws ArgumentError eof(stream)  # close
 
         @testset "readuntil" begin
             stream = InputBuffer(b"")
@@ -277,33 +272,12 @@ using CRC32: crc32
             @test data == zeros(UInt8, 5)
         end
     end
-    @testset "closing" begin
+    @testset "closing is no-op" begin
         b = InputBuffer(b"foo")
-        mark(b)
-        @test !iswritable(b)
-        @test isopen(b)
-        @test isreadable(b)
-        @test bytesavailable(b) == 3
-        read(b)
-        @test !iswritable(b)
-        @test isopen(b)
-        @test isreadable(b)
-        @test eof(b)
-        @test bytesavailable(b) == 0
         @test isnothing(close(b))
-        @test !isopen(b)
-        @test !isreadable(b)
+        @test isopen(b)
+        @test isreadable(b)
         @test !iswritable(b)
-        @test_throws ArgumentError eof(b)
-        @test !ismarked(b)
-        @test_throws ArgumentError mark(b)
-        @test_throws ArgumentError position(b)
-        @test_throws ArgumentError bytesavailable(b)
-        @test_throws ArgumentError read(b)
-        @test_throws ArgumentError read(b, String)
-        @test_throws ArgumentError read(b, UInt8)
-        @test_throws ArgumentError readbytes!(b, UInt8[])
-        @test isnothing(close(b)) # second close should be noop
     end
     @testset "crc32" begin
         for trial in 1:100


### PR DESCRIPTION
I can't think of a good reason to have `close` do anything.

This significantly improves the performance of byte reading in some cases:

```julia-repl
julia> using InputBuffers
julia> function readchars(io)
           s = 0
           while !eof(io)
               s += read(io, UInt8)
           end
           return s
       end;
julia> d = rand(UInt8, 2^30);
julia> @time readchars(InputBuffer(d))
```

This PR: 0.039790 seconds (2 allocations: 64 bytes)
Main: 0.362090 seconds (2 allocations: 64 bytes)